### PR TITLE
Update Saturday schedule with finalized workshop times and Sunday ceremony details

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,32 +566,32 @@
 
  <tr>
  <th scope="row">12:00 - 1:00 PM</th>
- <td>Lunch (PDS - In Person)</td>
+ <td>Lunch and Project Mentorship (PDS Upper School Steam Center - In Person)</td>
  </tr>
 
  <tr>
- <th scope="row">1:00 - 2:00 PM</th>
- <td>Robotics - Vivann &amp; Ark (PDS, Steam Center) | Keyboard Building - Ankith</td>
+ <th scope="row">1:00 - 1:30 PM</th>
+ <td>Intro to Godot Game Engine - Justin Philip '26 (PDS)</td>
  </tr>
 
  <tr>
- <th scope="row">2:00 - 3:00 PM</th>
- <td>(PDS) | Intro to Godot Game Engine - Justin</td>
+ <th scope="row">1:30 - 2:00 PM</th>
+ <td>Intro to Python - Aadit Gupta '29 (PDS)</td>
  </tr>
 
  <tr>
- <th scope="row">3:00 - 4:00 PM</th>
- <td>Tech Interview Prep/Competition - Max &amp; Kyle (PDS) | Intro to C - Andrew</td>
+ <th scope="row">2:00 - 2:30 PM</th>
+ <td>Keyboard Building - Ankith Namireddy '26 (PDS)</td>
  </tr>
 
  <tr>
- <th scope="row">4:00 - 5:00 PM</th>
- <td>Squash Project - Dhruv (PDS) | Tech in Finance - Sutej</td>
+ <th scope="row">2:30 - 3:00 PM</th>
+ <td>Tech Interview Prep/Competition - Max Naumann '28 &amp; Kyle Chen '28 (PDS)</td>
  </tr>
 
  <tr>
- <th scope="row">5:00 - 6:00 PM</th>
- <td>Chess Tournament - Ray, Andrew (chess.com)</td>
+ <th scope="row">7:00 - 8:00 PM</th>
+ <td>Chess Tournament - Ray Dubey '29 &amp; Andrew Dai '26 (remote on chess.com)</td>
  </tr>
 
  <tr>
@@ -600,13 +600,13 @@
  </tr>
 
  <tr>
- <th scope="row">TBD</th>
+ <th scope="row">9:00 AM</th>
  <td>Hacking period ends</td>
  </tr>
 
  <tr>
- <th scope="row">TBD</th>
- <td>Judging &amp; Closing Ceremony</td>
+ <th scope="row">3:30 PM</th>
+ <td>Award Ceremony</td>
  </tr>
 
  </tbody>


### PR DESCRIPTION
## Summary
- Replaced placeholder Saturday workshops with finalized 30-minute time slots and full presenter names/grad years
- Updated Sunday times from TBD to 9:00 AM (hacking ends) and 3:30 PM (Award Ceremony)
- Renamed "Judging & Closing Ceremony" to "Award Ceremony"

## Changes
- 12:00–1:00 PM: Lunch → Lunch and Project Mentorship (PDS Upper School Steam Center)
- 1:00–1:30 PM: Intro to Godot Game Engine – Justin Philip '26
- 1:30–2:00 PM: Intro to Python – Aadit Gupta '29
- 2:00–2:30 PM: Keyboard Building – Ankith Namireddy '26
- 2:30–3:00 PM: Tech Interview Prep/Competition – Max Naumann '28 & Kyle Chen '28
- 7:00–8:00 PM: Chess Tournament – Ray Dubey '29 & Andrew Dai '26 (remote on chess.com)
- Sunday 9:00 AM: Hacking period ends
- Sunday 3:30 PM: Award Ceremony

🤖 Generated with [Claude Code](https://claude.com/claude-code)